### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,16 +20,16 @@ play	KEYWORD2
 
 Heartbeat	KEYWORD1
 
-DelayRun    KEYWORD1
-startDelayed    KEYWORD2
+DelayRun	KEYWORD1
+startDelayed	KEYWORD2
 
-Dimmer    KEYWORD1
-startPulsate    KEYWORD2
-hold    KEYWORD2
-off    KEYWORD2
-revertDirection    KEYWORD2
-setFrequency    KEYWORD2
-getUpperLimit    KEYWORD2
+Dimmer	KEYWORD1
+startPulsate	KEYWORD2
+hold	KEYWORD2
+off	KEYWORD2
+revertDirection	KEYWORD2
+setFrequency	KEYWORD2
+getUpperLimit	KEYWORD2
 
-FrequencyTask    KEYWORD1
-setFrequency    KEYWORD2
+FrequencyTask	KEYWORD1
+setFrequency	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords